### PR TITLE
Change the method of converting the 12 bit sampled ADC value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MAX1704X
-version=1.0.0
+version=1.0.1
 author=Daniel Porrey <daniel.porrey@hotmail.com>
 maintainer=Daniel Porrey <daniel.porrey@hotmail.com>
 sentence=Arduino library for MAX17043/MAX17044 lithium ion battery fuel gauge.

--- a/src/MAX17043.h
+++ b/src/MAX17043.h
@@ -1,7 +1,7 @@
 /*
  * MAX1704X Arduino Library for MAX17043 and MAX17044 Fuel Gauge.
  *
- * Version 1.0.0 
+ * Version 1.0.1
  * Copyright © 2018 Daniel Porrey. All Rights Reserved.
  * https://github.com/porrey/max1704x
  *
@@ -30,8 +30,8 @@ extern MAX1704X FuelGauge;
 
 // ***
 // *** The MAX17043 is a one-cell device with a
-// *** a voltage measurement range of 0 to 5 V.
+// *** a voltage measurement range of 0 to 5 V in 1.25 mV increments.
 // ***
-MAX1704X FuelGauge = MAX1704X(5);
+MAX1704X FuelGauge = MAX1704X(1.25);
 
 #endif

--- a/src/MAX17044.h
+++ b/src/MAX17044.h
@@ -1,7 +1,7 @@
 /*
  * MAX1704X Arduino Library for MAX17043 and MAX17044 Fuel Gauge.
  *
- * Version 1.0.0 
+ * Version 1.0.1
  * Copyright © 2018 Daniel Porrey. All Rights Reserved.
  * https://github.com/porrey/max1704x
  *
@@ -30,8 +30,8 @@ extern MAX1704X FuelGauge;
 
 // ***
 // *** The MAX17044 is a two-cell device with a
-// *** a voltage measurement range of 0 to 10 V.
+// *** a voltage measurement range of 0 to 10 V in 2.50 mV increments.
 // ***
-MAX1704X FuelGauge = MAX1704X(10);
+MAX1704X FuelGauge = MAX1704X(2.50);
 
 #endif

--- a/src/MAX1704X.cpp
+++ b/src/MAX1704X.cpp
@@ -1,7 +1,7 @@
 /*
  * MAX1704X Arduino Library for MAX17043 and MAX17044 Fuel Gauge.
  *
- * Version 1.0.0 
+ * Version 1.0.1
  * Copyright © 2018 Daniel Porrey. All Rights Reserved.
  * https://github.com/porrey/max1704x
  *
@@ -23,9 +23,9 @@
  */
 #include "MAX1704X.h"
 
-MAX1704X::MAX1704X(float maxVoltage)
+MAX1704X::MAX1704X(float voltageIncrement)
 {
-  this->_maxVoltage = maxVoltage;
+  this->_voltageIncrement = voltageIncrement;
 }
 
 void MAX1704X::begin()
@@ -44,9 +44,10 @@ uint16_t MAX1704X::adc()
 float MAX1704X::voltage()
 {
   // ***
-  // *** The MAX1704X is a 12-bit ADC measuring 0 to 5 volts.
+  // *** The MAX1704X has a 12-bit ADC measuring 0 to 5 or 10 Volts in differing
+  // *** increments.
   // ***
-  return (float)(this->adc() / 4096.0 * this->_maxVoltage);
+  return (float)(this->adc() * this->_voltageIncrement);
 }
 
 float MAX1704X::percent()

--- a/src/MAX1704X.h
+++ b/src/MAX1704X.h
@@ -1,7 +1,7 @@
 /*
  * MAX1704X Arduino Library for MAX17043 and MAX17044 Fuel Gauge.
  *
- * Version 1.0.0 
+ * Version 1.0.1
  * Copyright © 2018 Daniel Porrey. All Rights Reserved.
  * https://github.com/porrey/max1704x
  *
@@ -65,7 +65,7 @@ class MAX1704X
     void setThreshold(uint8_t threshold);
 
   protected:
-    float _maxVoltage;
+    float _voltageIncrement;
     uint8_t thresholdToConfig(uint8_t threshold);
     uint8_t configToThreshold(uint8_t config);
     uint16_t readRegister16(uint8_t registerId);


### PR DESCRIPTION
Change the method of converting the 12 bit sampled ADC value to a voltage.  It is calculating a value that is to low.

Currently this is performed by scaling the value of 0 to 4095 to a value of
0.0 to 5.0 (or 10.0) volts.  However the datasheet states that the ADC
measures the voltage in increments of 1.25 mV (or 2.50 mV).  So we simply
multiply the ADC reading by the appropriate mV increment.